### PR TITLE
Fix tests

### DIFF
--- a/spec/parser/divider_spec.rb
+++ b/spec/parser/divider_spec.rb
@@ -51,7 +51,7 @@ describe Onix3::Parser::Divider do
       d = Onix3::Parser::Divider.new(StringIO.new(simple_onix))
       doc = d.document_for_products([])
       p = Nokogiri.XML(doc) { |config| config.nonet }
-      expect(p).to be_true
+      expect(p).to be_truthy
     end
 
     it "should contain products" do
@@ -91,7 +91,7 @@ describe Onix3::Parser::Divider do
       d = Onix3::Parser::Divider.new(StringIO.new(simple_onix))
       start = d.document_start
       p = Nokogiri.XML(start + d.document_end) { |config| config.nonet }
-      expect(p).to be_true
+      expect(p).to be_truthy
     end
 
   end
@@ -140,7 +140,7 @@ describe Onix3::Parser::Divider do
     end
 
     it "should allow a namespaced attribute for the root tag" do
-      pending "Nokogiri issue 843" # https://github.com/sparklemotion/nokogiri/issues/843
+      skip "Nokogiri issue 843" # https://github.com/sparklemotion/nokogiri/issues/843
     end
 
     it "should copy the exact product" do
@@ -154,7 +154,7 @@ describe Onix3::Parser::Divider do
       d = Onix3::Parser::Divider.new(StringIO.new(simple_onix))
       d.each_product_document do |doc|
         p = Nokogiri.XML(doc) { |config| config.nonet }
-        expect(p).to be_true
+        expect(p).to be_truthy
       end
     end
 


### PR DESCRIPTION
**Size**: S

## Functional description

Before working on a feature, I wanted to make sure I could make the tests pass on master. That was not possible, apparently because the tests are not up-to-date with the Rspec version we use. :thinking: 

## Code modifications

1. Adapt tests that used the be_true Rspec matcher, that was renamed to be_truthy in Rspec ≥3.
2. Use skip instead of pending for a non-implemented test: starting from Rspec 3, pending specs are expected to fail because they represent something that cannot be tested due to currently failing code.