### PR TITLE
Fix Divider for ONIX files using short tags

### DIFF
--- a/lib/onix3/data/loader.rb
+++ b/lib/onix3/data/loader.rb
@@ -13,7 +13,7 @@ module Onix3
       end
 
       def load_tags
-        YAML.load( File.read(tags_filename, nil, nil, ENCODING) )
+        YAML.load(File.read(tags_filename, nil, nil, encoding: ENCODING))
       end
 
       def short_tag_for(name)

--- a/lib/onix3/parser/divider.rb
+++ b/lib/onix3/parser/divider.rb
@@ -22,7 +22,7 @@ module Onix3
           tag = (prefix ? prefix+":" : "") + reader.tag("ONIXMessage")
           @opening = "<#{tag}#{attribs}>"
           move_to_header
-          @header = reader.local_name == "Header" ? reader.outer_xml : ''
+          @header = reader.local_name == reader.tag("Header") ? reader.outer_xml : ''
           @closing = "</#{tag}>"
         end
         @document_started = true

--- a/lib/onix3/parser/onix_reader.rb
+++ b/lib/onix3/parser/onix_reader.rb
@@ -47,7 +47,7 @@ module Onix3
       end
 
       def short_tag_for(name)
-        data.short_tags.fetch(name)
+        data.short_tag_for(name)
       end
 
       def data


### PR DESCRIPTION
**Size**: S
## Functional description

Splitting ONIX files that use short tags instead of reference names was not working.
This aims to fix this issue ([VIV-1737](https://tea-ebook.atlassian.net/browse/VIV-1737)).

## Code modifications

1. Fix the loading of the file containing mapping between reference names and short tags.
2. Fix the call to the method handling the retrieval of the short tag from the reference name.
3. Fix the handling of ONIX headers, which was not taking the possibility of the file using short tags into account.

## Tests

Add new divider test cases with short tags ONIX content.

## Other details

The method that is used in tearex when splitting files is `Onix3::Parser::Divider#each_product_document` ([see the code](https://github.com/TEA-ebook/tearex/blob/84213ee9c12ebb962ddcf367ec37b7e70913c843/lib/utils/file_splitter.rb#L42-L54)).

No CI for this project; tests are green on my machine.